### PR TITLE
Make the instructions a code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Inspired by [Sandi Metz 99 Bottles Book](https://github.com/sandimetz/99bottles)
 
 ## Instructions
 
-git clone https://github.com/cmar/oop-workshop
-cd oop-workshop
-bundle
-rake
+    git clone https://github.com/cmar/oop-workshop
+    cd oop-workshop
+    bundle
+    rake


### PR DESCRIPTION
Make the instructions a code block by changing the markdown syntax to use the four spaces